### PR TITLE
refactor: 💡 aws_iam_openid_connect_providerからthumbprint_listをコメ

### DIFF
--- a/modules/iam/provider/oidc/github/oidc_provider.tf
+++ b/modules/iam/provider/oidc/github/oidc_provider.tf
@@ -1,9 +1,10 @@
 locals {
   domain                             = "https://token.actions.githubusercontent.com"
-  openid_provider_configuration_path = "/.well-known/openid-configuration"
-  openid_configuration_url           = "${local.domain}${local.openid_provider_configuration_path}"
+  //openid_provider_configuration_path = "/.well-known/openid-configuration"
+  //openid_configuration_url           = "${local.domain}${local.openid_provider_configuration_path}"
 }
 
+/*
 data "http" "openid_configuration" {
   url = local.openid_configuration_url
 }
@@ -11,13 +12,24 @@ data "http" "openid_configuration" {
 data "tls_certificate" "encryption_key" {
   url = jsondecode(data.http.openid_configuration.response_body).jwks_uri
 }
+*/
 
 resource "aws_iam_openid_connect_provider" "github" {
   url = local.domain
   client_id_list = [
     "sts.amazonaws.com"
   ]
+  /*
+  現在はGitHubのOIDCプロバイダーの証明書が自動で取得されているため、
+  AWS側でのSHA1フィンガープリントの登録は不要になっています。
+  参考：
+  - https://wandfuldays.com/articles/c7cx_y8_ycc/
+  - https://zenn.dev/not75743/articles/60a8f9526ee32b
+  - https://github.com/aws-actions/configure-aws-credentials/pull/764/files
+  - https://github.com/hashicorp/terraform-provider-aws/pull/37255
+  フィンガープリントは、"2b18947a6a9fc7764fd8b5fb18a863b0c6dac24f"に現在は置き換えられています。
   thumbprint_list = [
     data.tls_certificate.encryption_key.certificates[0].sha1_fingerprint
   ]
+  */
 }


### PR DESCRIPTION
現在はAWSからのGitHub ActionsへのOIDC認証ではフィンガープリントが指定不要となっている。
そのため、thumbprint_listをコメントアウトした。
