### PR TITLE
fix: 🐛 ECR名修正

### DIFF
--- a/.github/workflows/build-and-push-container-image.yaml
+++ b/.github/workflows/build-and-push-container-image.yaml
@@ -47,4 +47,4 @@ jobs:
         with:
           context: "docker/html"
           push: true
-          tags: ${{ steps.login-ecr.outputs.registry }}/simple-${{ github.event.inputs.environment }}-web:${{ steps.get-image-tag.outputs.image-tag }}
+          tags: ${{ steps.login-ecr.outputs.registry }}/sample-${{ github.event.inputs.environment }}-web:${{ steps.get-image-tag.outputs.image-tag }}


### PR DESCRIPTION
Build and push Docker image to Amazon ECR stepのタグにあるECR名の修正
誤り：${{ steps.login-ecr.outputs.registry }}/simple-${{ github.event.inputs.environment }}-web
正：${{ steps.login-ecr.outputs.registry }}/sample-${{ github.event.inputs.environment }}-web
