### PR TITLE
fix: 🐛 ビルドプロセスに"linux/amd64"を追加

### DIFF
--- a/.github/workflows/build-and-push-container-image.yaml
+++ b/.github/workflows/build-and-push-container-image.yaml
@@ -46,5 +46,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: "docker"
+          platforms: "linux/amd64"
           push: true
           tags: ${{ steps.login-ecr.outputs.registry }}/sample-${{ github.event.inputs.environment }}-web:${{ steps.get-image-tag.outputs.image-tag }}


### PR DESCRIPTION
docker/build-push-action@v6でplatforms: "linux/amd64"が指定されていなかったため、デプロイに失敗していた。
