### PR TITLE
separate state

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ terraform apply
 ```sh
 cd systems/ecs/service/alb
 terarform init
-terraform apply -target=module.alb_security_group
+terraform apply
 ```
 
 ### 6. ECS Serviceデプロイ

--- a/README.md
+++ b/README.md
@@ -29,16 +29,9 @@ terarform init
 terraform apply
 ```
 
-### 5. ALB用Security Groupデプロイ
-ECS Serviceデプロイ時にALB用とECS用のSecurity Groupを作成したいが、ECS用のSecurity GroupでALB用Security Group Arnを許可している。ALB用Security Group Arnはデプロイしないと決まらないため、以下エラーが発生する。  
-+++++++++++++++++++  
-The "for_each" map includes keys derived from resource attributes that cannot be determined until apply, and so Terraform cannot determine the full set of keys that will identify the instances of this resource.
-When working with unknown values in for_each, it's better to define the map keys statically in your configuration and place apply-time results only in the map values.
-Alternatively, you could use the -target planning option to first apply only the resources that the for_each value depends on, and then apply a second time to fully converge.
-+++++++++++++++++++  
-よって最初に以下コマンドでALB用Security Groupを作成する
+### 5. ALBデプロイ
 ```sh
-cd systems/ecs/service
+cd systems/ecs/service/alb
 terarform init
 terraform apply -target=module.alb_security_group
 ```

--- a/systems/ecs/service/alb/.terraform.lock.hcl
+++ b/systems/ecs/service/alb/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "6.14.1"
+  hashes = [
+    "h1:oacWXQzS6BmkN3lcKKxafYOGUQcUOpneJikw8hqLUyA=",
+    "zh:14d0b4b3dffb3368e6257136bbab1f93d419863dd65d99ef80ca2c1dd3c72a1e",
+    "zh:1de3601251f87a0a989c4b3474baa2efcaf491804f8d7afe15421b728bac5dc5",
+    "zh:2cfe42b853a3b4117bdbb73e5715035eac9b8d753d6e653fd5f30a807a36b985",
+    "zh:3dd8a0336face356928faf2396065634739ef2c3ac3dcaa655570df205559fd9",
+    "zh:42712baca386b84e089b1db8b7844038557f4039b32d8702611aa67eadef7d0f",
+    "zh:4ffc698099e4d7ffc6b0490a4e78ad66b041afd54e988b8bf8e229bcdd4b3ead",
+    "zh:52a6a3b01cb34394b0d06b273b27702fb9d795290a02e5824e198315787e8446",
+    "zh:56eae388c48a844401e44811719dc23be84de538468fd12b7265b06acbf4b51d",
+    "zh:614a918fdf27416b2ee2ce1737895b791f59f9deff3b61246c62a992eabfb8eb",
+    "zh:68605e159177b57fdc4a26bb2caff69a7b69593a601145b7ab5a86fd44b28b9f",
+    "zh:771ac00fd5f211052d735ff0e4b9ec67288abd1e22ffea4ed774aec73c7e5687",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a1355841161e5b53dc3078c88aae1972fd4a9c0d30309b18b1951137b96571fa",
+    "zh:a3c8ca40c1fa7ad76d3d4c3c0039b66a93cc96399e757d2caa0b5cdedce9d3e8",
+    "zh:c77e02a72ef9eb0eb65faaf84c33af843520622dbb51ec31d04ca371bd4d4ee8",
+  ]
+}

--- a/systems/ecs/service/alb/resource.tf
+++ b/systems/ecs/service/alb/resource.tf
@@ -1,0 +1,109 @@
+############
+# ALB
+############
+
+data "aws_vpc" "vpc" {
+  tags = {
+    Name = "${local.service_name}-${local.env}-vpc"
+    Env  = local.env
+  }
+}
+
+data "aws_subnets" "public_subnets" {
+  filter {
+    name = "vpc-id"
+    values = [
+      data.aws_vpc.vpc.id
+    ]
+  }
+  tags = {
+    Env   = local.env
+    Scope = "public"
+  }
+}
+
+data "aws_acm_certificate" "certificate" {
+  domain = local.certificate_domain
+}
+
+module "alb_security_group" {
+  source = "../../../../modules/vpc/security_group"
+
+  service_name   = local.service_name
+  service_suffix = "alb"
+  env            = local.env
+  vpc_id         = data.aws_vpc.vpc.id
+  # 内向き通信(ingress)設定
+  security_group_ingress_cidrs = [
+    "0.0.0.0/0"
+  ]
+  # security_group_ingress_sgs = []
+  # security_group_ingress_allow_self = false
+  security_group_ingress_ports = [
+    80,
+    443
+  ]
+
+  # 外向け通信(egress)設定
+  # security_group_egress_cidrs = ["0.0.0.0/0"]
+  # security_group_egress_allow_self = false
+}
+
+module "alb" {
+  source = "../../../../modules/ecs/service/alb"
+
+  service_name = local.service_name
+  env          = local.env
+
+  # ALB本体設定
+  alb_subnet_ids = data.aws_subnets.public_subnets.ids # ALBを紐付けるサブネットID
+  # ALBに付与するセキュリティグループのID
+  alb_security_group_ids = [
+    module.alb_security_group.security_group_id
+  ]
+  # alb_additional_tags = {} # モジュール内の各種リソースに付与する追加タグ
+
+  # ログ設定
+  # alb_log_transition_in_days = 90 # ログをSTANDARDからSTANDARD IAに移動するまでの日数
+  # alb_log_expiration_in_days = 550 # ログを削除するまでの保管期間
+
+  # リスナー設定(HTTPリスナー)
+  # alb_enable_http_listener = true # HTTPリスナーを有効化
+  # alb_enable_redirect_http_to_https = true # HTTPリスナーではHTTP -> HTTPSにリダイレクト
+
+  # リスナー設定(HTTPSリスナー)
+  # alb_enable_https_listener = true # HTTPSリスナーを有効化
+  # alb_https_listener_ssl_policy = "ELBSecurityPolicy-2016-08"
+  alb_https_certificate_arn = data.aws_acm_certificate.certificate.arn # HTTPSリスナーに紐付ける証明書ARNを指定
+
+  # ターゲットグループ設定
+  alb_vpc_id = data.aws_vpc.vpc.id # ターゲットグループを紐付けるVPC ID
+  # alb_target_group_port = 80 # ターゲットグループの待受ポート
+  # alb_target_group_health_check_port = 80 # ヘルスチェック用ポート
+  # alb_target_group_health_check_path = "/" # ヘルスチェック用パス
+  # alb_target_group_health_check_interval = 30 # ヘルスチェックの間隔
+  # alb_target_group_health_check_timeout = 10 # ヘルスチェックのタイムアウト
+  # alb_target_group_health_check_healthy_threshold = 3 # ヘルスチェック先をHealthyとみなすヘルスチェック回数
+  # alb_target_group_health_check_unhealthy_threshold = 0 # ヘルスチェック先をUnhealthyとみなすヘルスチェック回数
+}
+
+############
+# Route53 Zone
+############
+# ALBのFQDNを登録する
+
+data "aws_route53_zone" "zone" {
+  name = local.dns_hosted_zone_domain
+}
+
+resource "aws_route53_record" "record" {
+  zone_id = data.aws_route53_zone.zone.zone_id
+  name    = local.dns_a_record
+  type    = "A"
+
+  alias {
+    name                   = module.alb.alb_fqdn
+    zone_id                = module.alb.alb_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/systems/ecs/service/alb/terraform.tf
+++ b/systems/ecs/service/alb/terraform.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "terraform-up-and-running-state-taniai"
+    key          = "090_ecs/service/alb/terraform.tfstate"
+    region       = "ap-northeast-1"
+    use_lockfile = true
+    encrypt      = true
+  }
+}

--- a/systems/ecs/service/alb/variables.tf
+++ b/systems/ecs/service/alb/variables.tf
@@ -1,0 +1,8 @@
+locals {
+  service_name = "sample"
+  env          = "dev"
+
+  dns_hosted_zone_domain = "jnytnai.click."
+  dns_a_record           = "terraform-sample.jnytnai.click."
+  certificate_domain     = "terraform-sample.jnytnai.click"
+}

--- a/systems/ecs/service/resource.tf
+++ b/systems/ecs/service/resource.tf
@@ -1,6 +1,14 @@
-############
-# ALB
-############
+/*
+  aws_ecs_cluster dataソースからARNを取得してECSサービスモジュールの呼び出しに渡す。
+  aws_caller_identity dataソースと、ARNルールを組み合わせてECSクラスターのARNを生成しても良い
+*/
+data "aws_ecs_cluster" "cluster" {
+  cluster_name = local.ecs_cluster_name
+}
+
+data "aws_ecs_task_definition" "task_definition" {
+  task_definition = local.ecs_task_family
+}
 
 data "aws_vpc" "vpc" {
   tags = {
@@ -9,103 +17,37 @@ data "aws_vpc" "vpc" {
   }
 }
 
-data "aws_acm_certificate" "certificate" {
-  domain = local.certificate_domain
-}
-
-# ECS用Security Group作成時に、 以下エラーが発生する。
-# +++++++++++++++++++
-# The "for_each" map includes keys derived from resource attributes that cannot be determined until apply, and so Terraform cannot determine the full set of keys that will identify the instances of this resource.
-# When working with unknown values in for_each, it's better to define the map keys statically in your configuration and place apply-time results only in the map values.
-# Alternatively, you could use the -target planning option to first apply only the resources that the for_each value depends on, and then apply a second time to fully converge.
-# +++++++++++++++++++
-# よって最初に以下コマンドでALB用Security Groupを作成する
-# terraform apply -target=module.alb_security_group
-module "alb_security_group" {
-  source = "../../../modules/vpc/security_group"
-
-  service_name   = local.service_name
-  service_suffix = "alb"
-  env            = local.env
-  vpc_id         = data.aws_vpc.vpc.id
-  # 内向き通信(ingress)設定
-  security_group_ingress_cidrs = [
-    "0.0.0.0/0"
-  ]
-  # security_group_ingress_sgs = []
-  # security_group_ingress_allow_self = false
-  security_group_ingress_ports = [
-    80,
-    443
-  ]
-
-  # 外向け通信(egress)設定
-  # security_group_egress_cidrs = ["0.0.0.0/0"]
-  # security_group_egress_allow_self = false
-}
-
-module "alb" {
-  source = "../../../modules/ecs/service/alb"
-
-  service_name = local.service_name
-  env          = local.env
-
-  # ALB本体設定
-  alb_subnet_ids = data.aws_subnets.public_subnets.ids # ALBを紐付けるサブネットID
-  # ALBに付与するセキュリティグループのID
-  alb_security_group_ids = [
-    module.alb_security_group.security_group_id
-  ]
-  # alb_additional_tags = {} # モジュール内の各種リソースに付与する追加タグ
-
-  # ログ設定
-  # alb_log_transition_in_days = 90 # ログをSTANDARDからSTANDARD IAに移動するまでの日数
-  # alb_log_expiration_in_days = 550 # ログを削除するまでの保管期間
-
-  # リスナー設定(HTTPリスナー)
-  # alb_enable_http_listener = true # HTTPリスナーを有効化
-  # alb_enable_redirect_http_to_https = true # HTTPリスナーではHTTP -> HTTPSにリダイレクト
-
-  # リスナー設定(HTTPSリスナー)
-  # alb_enable_https_listener = true # HTTPSリスナーを有効化
-  # alb_https_listener_ssl_policy = "ELBSecurityPolicy-2016-08"
-  alb_https_certificate_arn = data.aws_acm_certificate.certificate.arn # HTTPSリスナーに紐付ける証明書ARNを指定
-
-  # ターゲットグループ設定
-  alb_vpc_id = data.aws_vpc.vpc.id # ターゲットグループを紐付けるVPC ID
-  # alb_target_group_port = 80 # ターゲットグループの待受ポート
-  # alb_target_group_health_check_port = 80 # ヘルスチェック用ポート
-  # alb_target_group_health_check_path = "/" # ヘルスチェック用パス
-  # alb_target_group_health_check_interval = 30 # ヘルスチェックの間隔
-  # alb_target_group_health_check_timeout = 10 # ヘルスチェックのタイムアウト
-  # alb_target_group_health_check_healthy_threshold = 3 # ヘルスチェック先をHealthyとみなすヘルスチェック回数
-  # alb_target_group_health_check_unhealthy_threshold = 0 # ヘルスチェック先をUnhealthyとみなすヘルスチェック回数
-}
-
-############
-# Route53 Zone
-############
-# ALBのFQDNを登録する
-
-data "aws_route53_zone" "zone" {
-  name = local.dns_hosted_zone_domain
-}
-
-resource "aws_route53_record" "record" {
-  zone_id = data.aws_route53_zone.zone.zone_id
-  name    = local.dns_a_record
-  type    = "A"
-
-  alias {
-    name                   = module.alb.alb_fqdn
-    zone_id                = module.alb.alb_zone_id
-    evaluate_target_health = false
+data "aws_subnets" "private_subnets" {
+  filter {
+    name = "vpc-id"
+    values = [
+      data.aws_vpc.vpc.id
+    ]
+  }
+  tags = {
+    Env   = local.env
+    Scope = "private"
   }
 }
 
-############
-# ECS
-############
+data "aws_security_group" "alb_security_group" {
+  filter {
+    name = "group-name"
+    values = [
+      "${local.service_name}-alb-${local.env}-sg"
+    ]
+  }
+  filter {
+    name = "vpc-id"
+    values = [
+      data.aws_vpc.vpc.id
+    ]
+  }
+}
+
+data "aws_alb_target_group" "alb_target_group" {
+  name = "${local.service_name}-${local.env}-alb-tg"
+}
 
 module "ecs_security_group" {
   source = "../../../modules/vpc/security_group"
@@ -123,7 +65,7 @@ module "ecs_security_group" {
     80
   ]
   security_group_ingress_sgs = [
-    module.alb_security_group.security_group_id
+    data.aws_security_group.alb_security_group.id
   ]
 
 
@@ -131,44 +73,6 @@ module "ecs_security_group" {
   # security_group_egress_cidrs = ["0.0.0.0/0"]
   # security_group_egress_allow_self = false
   # security_group_egress_sgs = []
-}
-
-/*
-  aws_ecs_cluster dataソースからARNを取得してECSサービスモジュールの呼び出しに渡す。
-  aws_caller_identity dataソースと、ARNルールを組み合わせてECSクラスターのARNを生成しても良い
-*/
-data "aws_ecs_cluster" "cluster" {
-  cluster_name = local.ecs_cluster_name
-}
-
-data "aws_ecs_task_definition" "task_definition" {
-  task_definition = local.ecs_task_family
-}
-
-data "aws_subnets" "public_subnets" {
-  filter {
-    name = "vpc-id"
-    values = [
-      data.aws_vpc.vpc.id
-    ]
-  }
-  tags = {
-    Env   = local.env
-    Scope = "public"
-  }
-}
-
-data "aws_subnets" "private_subnets" {
-  filter {
-    name = "vpc-id"
-    values = [
-      data.aws_vpc.vpc.id
-    ]
-  }
-  tags = {
-    Env   = local.env
-    Scope = "private"
-  }
 }
 
 module "ecs_service" {
@@ -191,7 +95,7 @@ module "ecs_service" {
   ecs_service_task_definition_arn = data.aws_ecs_task_definition.task_definition.arn_without_revision
 
   # ロードバランサ設定
-  ecs_service_alb_target_group_arn            = module.alb.alb_target_group_arn
+  ecs_service_alb_target_group_arn            = data.aws_alb_target_group.alb_target_group.arn
   ecs_service_alb_target_group_container_name = "nginx"
   # ecs_service_alb_target_group_container_port = 80
 

--- a/systems/ecs/service/variables.tf
+++ b/systems/ecs/service/variables.tf
@@ -4,9 +4,4 @@ locals {
 
   ecs_cluster_name = "${local.service_name}-${local.env}-cluster"
   ecs_task_family  = "${local.service_name}-${local.env}-task"
-
-
-  dns_hosted_zone_domain = "jnytnai.click."
-  dns_a_record           = "terraform-sample.jnytnai.click."
-  certificate_domain     = "terraform-sample.jnytnai.click"
 }


### PR DESCRIPTION
- **fix: 🐛 ALBとECS ServiceのModule呼び出しを分けた**
- **fix: 🐛 ALBデプロイ時のtargetを削除**

元々ECS Service用SGがALB用SGを許可するようになっており、ALB用SG作成Moduleに依存していた。
この場合、ALB用SG作成Moduleが完了しないとARNが分からず、そのままではエラーが出ていた。
そこで、target指定でALB用SGを最初に作成してからECS Serviceを作成する流れにしていたが煩雑だった。
ALBとECS ServiceのModule呼び出しを分け、Stateを分けることで、dataブロックでARNを取得できるようにした。
